### PR TITLE
Use fake timers in sleep test

### DIFF
--- a/backend/src/utils/time.test.ts
+++ b/backend/src/utils/time.test.ts
@@ -1,10 +1,20 @@
 import { sleep } from './time';
 
 describe('sleep', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('resolves after the specified time', async () => {
     const start = Date.now();
-    await sleep(50);
+    const promise = sleep(50);
+    jest.advanceTimersByTime(50);
+    await promise;
     const elapsed = Date.now() - start;
-    expect(elapsed).toBeGreaterThanOrEqual(45); // allow some margin
+    expect(elapsed).toBeGreaterThanOrEqual(50);
   });
 });


### PR DESCRIPTION
## Summary
- mock timers in backend `sleep` test

## Testing
- `npm run test:backend`

------
https://chatgpt.com/codex/tasks/task_e_686cba5bb3508330ab2aa56b65cd8a07