### PR TITLE
Add route DTOs and re-export types

### DIFF
--- a/backend/src/client.ts
+++ b/backend/src/client.ts
@@ -10,3 +10,32 @@ const client = hc<RoutesApp>('');
 export type Client = typeof client;
 
 export const hcWithType = (...args: Parameters<typeof hc>): Client => hc<RoutesApp>(...args);
+
+// Re-export route DTOs for consumers
+export type {
+  AuthTokens,
+  CreateUserRequest,
+  CreateUserResponse,
+  LoginRequest,
+  LoginResponse,
+  LogoutRequest,
+  LogoutResponse,
+  RefreshRequest,
+  RefreshResponse,
+  UserDto,
+} from './routes/auth.types';
+export type { MovieResponse, MovieSourceDto, StreamingKeyResponse } from './routes/movie.types';
+export type {
+  StreamParams,
+  StreamQuery,
+  StreamResponse,
+  StreamSourceDto,
+} from './routes/stream.types';
+export type {
+  DeviceAuthCheckRequest,
+  DeviceAuthCheckResponse,
+  DeviceAuthResponse,
+  TraktAdminAssociateRequest,
+  TraktAdminAssociateResponse,
+  TraktAssociationResponse,
+} from './routes/trakt.types';

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -9,6 +9,8 @@ import { createRateLimitMiddlewareFactory } from '@middleware/rate-limit.middlew
 import type { AuthService } from '@services/auth/auth.service';
 import type { AuditLogService } from '@services/security/audit-log.service';
 
+import type { LoginResponse, LogoutResponse, RefreshResponse, UserDto } from './auth.types';
+
 export const createAuthRoutes = (authService: AuthService, auditLogService: AuditLogService) => {
   const rateLimitGuard = createRateLimitMiddlewareFactory(auditLogService);
 
@@ -44,7 +46,8 @@ export const createAuthRoutes = (authService: AuthService, auditLogService: Audi
           context,
         });
 
-        return context.json(tokens);
+        const response: LoginResponse = tokens;
+        return context.json(response);
       }
     )
     .post(
@@ -70,7 +73,8 @@ export const createAuthRoutes = (authService: AuthService, auditLogService: Audi
           context,
         });
 
-        return context.json(refreshResponse.tokens);
+        const response: RefreshResponse = refreshResponse.tokens;
+        return context.json(response);
       }
     )
     .post(
@@ -95,7 +99,8 @@ export const createAuthRoutes = (authService: AuthService, auditLogService: Audi
           });
         }
 
-        return context.json({ message: 'Logged out successfully' });
+        const response: LogoutResponse = { message: 'Logged out successfully' };
+        return context.json(response);
       }
     )
     .post(
@@ -114,12 +119,12 @@ export const createAuthRoutes = (authService: AuthService, auditLogService: Audi
         const { email, password, role } = context.req.valid('json');
 
         const newUser = await authService.createUser(email, password, role as UserRole);
-
-        return context.json({
+        const response: UserDto = {
           id: newUser.id,
           email: newUser.email,
           role: newUser.role,
-        });
+        };
+        return context.json(response);
       }
     );
 };

--- a/backend/src/routes/auth.types.ts
+++ b/backend/src/routes/auth.types.ts
@@ -1,0 +1,38 @@
+import type { AuthTokens } from '@services/auth/auth.types';
+export type { AuthTokens } from '@services/auth/auth.types';
+
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+export type LoginResponse = AuthTokens;
+
+export interface RefreshRequest {
+  refreshToken: string;
+}
+
+export type RefreshResponse = AuthTokens;
+
+export interface LogoutRequest {
+  refreshToken: string;
+}
+
+export interface LogoutResponse {
+  message: string;
+}
+
+import type { UserRole } from '@entities/user.entity';
+export interface CreateUserRequest {
+  email: string;
+  password: string;
+  role: UserRole;
+}
+
+export interface UserDto {
+  id: string;
+  email: string;
+  role: UserRole;
+}
+
+export type CreateUserResponse = UserDto;

--- a/backend/src/routes/movie.types.ts
+++ b/backend/src/routes/movie.types.ts
@@ -1,0 +1,41 @@
+import type { Source, VideoCodec } from '@miauflix/source-metadata-extractor';
+import type { Quality } from '@miauflix/source-metadata-extractor';
+
+export interface MovieSourceDto {
+  id: number;
+  quality: Quality | '3D' | null;
+  size: number;
+  videoCodec: VideoCodec | null;
+  broadcasters: number | null;
+  watchers: number | null;
+  source: Source | null;
+  hasDataFile: boolean;
+}
+
+export interface MovieResponse {
+  id: number;
+  tmdbId: number;
+  imdbId: string | null;
+  title: string;
+  overview: string;
+  tagline: string;
+  releaseDate: string;
+  runtime: number;
+  poster: string;
+  backdrop: string;
+  logo: string;
+  genres: string[];
+  popularity: number;
+  rating: number;
+  sources?: MovieSourceDto[];
+}
+
+export interface StreamingKeyResponse {
+  streamingKey: string;
+  quality: Quality | '3D' | null;
+  size: number;
+  videoCodec: VideoCodec | null;
+  broadcasters: number | null;
+  watchers: number | null;
+  expiresAt: Date;
+}

--- a/backend/src/routes/stream.routes.ts
+++ b/backend/src/routes/stream.routes.ts
@@ -8,6 +8,8 @@ import type { AuthService } from '@services/auth/auth.service';
 import type { AuditLogService } from '@services/security/audit-log.service';
 import type { StreamService } from '@services/stream/stream.service';
 
+import type { StreamResponse } from './stream.types';
+
 export const createStreamRoutes = (
   authService: AuthService,
   streamService: StreamService,
@@ -62,18 +64,16 @@ export const createStreamRoutes = (
           );
         }
 
-        return context.json(
-          {
-            status: 'not implemented',
-            source: {
-              id: source.id,
-              quality: source.quality,
-              size: source.size,
-              videoCodec: source.videoCodec,
-            },
+        const response: StreamResponse = {
+          status: 'not implemented',
+          source: {
+            id: source.id,
+            quality: source.quality,
+            size: source.size,
+            videoCodec: source.videoCodec,
           },
-          501
-        );
+        };
+        return context.json(response, 501);
       } catch (error: unknown) {
         console.error('Failed to stream content:', error);
 

--- a/backend/src/routes/stream.types.ts
+++ b/backend/src/routes/stream.types.ts
@@ -1,0 +1,23 @@
+import type { VideoCodec } from '@miauflix/source-metadata-extractor';
+import type { Quality } from '@miauflix/source-metadata-extractor';
+
+export interface StreamParams {
+  token: string;
+}
+
+export interface StreamQuery {
+  quality?: Quality | 'auto';
+  hevc?: boolean;
+}
+
+export interface StreamSourceDto {
+  id: number;
+  quality: Quality | '3D' | null;
+  size: number;
+  videoCodec: VideoCodec | null;
+}
+
+export interface StreamResponse {
+  status: string;
+  source: StreamSourceDto;
+}

--- a/backend/src/routes/trakt.routes.ts
+++ b/backend/src/routes/trakt.routes.ts
@@ -9,6 +9,13 @@ import { createRateLimitMiddlewareFactory } from '@middleware/rate-limit.middlew
 import type { AuditLogService } from '@services/security/audit-log.service';
 import type { TraktService } from '@services/trakt/trakt.service';
 
+import type {
+  DeviceAuthCheckResponse,
+  DeviceAuthResponse,
+  TraktAdminAssociateResponse,
+  TraktAssociationResponse,
+} from './trakt.types';
+
 export const createTraktRoutes = (traktService: TraktService, auditLogService: AuditLogService) => {
   const rateLimitGuard = createRateLimitMiddlewareFactory(auditLogService);
 
@@ -23,14 +30,15 @@ export const createTraktRoutes = (traktService: TraktService, auditLogService: A
           try {
             const deviceAuth = await traktService.initiateDeviceAuth();
 
-            return context.json({
+            const response: DeviceAuthResponse = {
               success: true,
               codeUrl: deviceAuth.codeUrl,
               userCode: deviceAuth.userCode,
               deviceCode: deviceAuth.deviceCode,
               expiresIn: deviceAuth.expiresIn,
               interval: deviceAuth.interval,
-            });
+            };
+            return context.json(response);
           } catch (error) {
             console.error('Trakt device auth initiation failed:', error);
             return context.json(
@@ -71,7 +79,8 @@ export const createTraktRoutes = (traktService: TraktService, auditLogService: A
               });
             }
 
-            return context.json(result);
+            const response: DeviceAuthCheckResponse = result;
+            return context.json(response);
           } catch (error) {
             console.error('Trakt device auth check failed:', error);
             return context.json(
@@ -92,11 +101,12 @@ export const createTraktRoutes = (traktService: TraktService, auditLogService: A
           try {
             const association = await traktService.getUserTraktAssociation(authUser.id);
 
-            return context.json({
+            const response: TraktAssociationResponse = {
               associated: !!association,
               traktUsername: association?.traktUsername || null,
               traktSlug: association?.traktSlug || null,
-            });
+            };
+            return context.json(response);
           } catch (error) {
             console.error('Failed to get Trakt association:', error);
             return context.json({ error: 'Failed to get Trakt association' }, 500);
@@ -134,14 +144,15 @@ export const createTraktRoutes = (traktService: TraktService, auditLogService: A
               },
             });
 
-            return context.json({
+            const response: TraktAdminAssociateResponse = {
               success: true,
               association: {
                 id: association.id,
                 traktSlug: association.traktSlug,
                 userEmail: association.user?.email || null,
               },
-            });
+            };
+            return context.json(response);
           } catch (error) {
             console.error('Failed to associate Trakt user:', error);
             return context.json({ error: 'Failed to associate Trakt user' }, 500);

--- a/backend/src/routes/trakt.types.ts
+++ b/backend/src/routes/trakt.types.ts
@@ -1,0 +1,38 @@
+export interface DeviceAuthResponse {
+  success: boolean;
+  codeUrl: string;
+  userCode: string;
+  deviceCode: string;
+  expiresIn: number;
+  interval: number;
+}
+
+export interface DeviceAuthCheckRequest {
+  deviceCode: string;
+}
+
+export type {
+  DeviceAuthCheckPending,
+  DeviceAuthCheckResponse,
+  DeviceAuthCheckSuccess,
+} from '@services/trakt/trakt.types';
+
+export interface TraktAssociationResponse {
+  associated: boolean;
+  traktUsername: string | null;
+  traktSlug: string | null;
+}
+
+export interface TraktAdminAssociateRequest {
+  traktSlug: string;
+  userEmail: string;
+}
+
+export interface TraktAdminAssociateResponse {
+  success: true;
+  association: {
+    id: string;
+    traktSlug: string;
+    userEmail: string | null;
+  };
+}

--- a/backend/src/services/auth/auth.service.ts
+++ b/backend/src/services/auth/auth.service.ts
@@ -13,6 +13,7 @@ import { InvalidTokenError } from '@errors/auth.errors';
 import type { RefreshTokenRepository } from '@repositories/refresh-token.repository';
 import type { StreamingKeyRepository } from '@repositories/streaming-key.repository';
 import type { UserRepository } from '@repositories/user.repository';
+import type { AuthTokens, StreamingToken } from '@services/auth/auth.types';
 import type { AuditLogService } from '@services/security/audit-log.service';
 import { InMemoryCache } from '@utils/in-memory-cache';
 import { generateSecurePassword } from '@utils/password.util';
@@ -24,11 +25,6 @@ import {
   parseStreamingKey,
   validateTokenPayload,
 } from './auth.util';
-
-interface StreamingToken {
-  movieId: number;
-  userId: string;
-}
 
 export class AuthService {
   private readonly userRepository: UserRepository;
@@ -118,7 +114,7 @@ export class AuthService {
     return isValid ? user : null;
   }
 
-  async generateTokens(user: User) {
+  async generateTokens(user: User): Promise<AuthTokens> {
     const accessToken = await this.generateAccessToken(user);
     const refreshToken = await this.generateRefreshToken(user);
 
@@ -212,7 +208,7 @@ export class AuthService {
   }
 
   async refreshAccessToken(refreshToken: string): Promise<{
-    tokens: { accessToken: string; refreshToken: string };
+    tokens: AuthTokens;
     email: string;
   } | null> {
     const refreshTokenPayload = await this.verifyRefreshToken(refreshToken);

--- a/backend/src/services/auth/auth.types.ts
+++ b/backend/src/services/auth/auth.types.ts
@@ -1,0 +1,9 @@
+export interface AuthTokens {
+  accessToken: string;
+  refreshToken: string;
+}
+
+export interface StreamingToken {
+  movieId: number;
+  userId: string;
+}

--- a/backend/src/services/trakt/trakt.service.ts
+++ b/backend/src/services/trakt/trakt.service.ts
@@ -1,6 +1,7 @@
 import type { Database } from '@database/database';
 import type { TraktUserRepository } from '@repositories/trakt-user.repository';
 import type { UserRepository } from '@repositories/user.repository';
+import type { DeviceAuthCheckResponse } from '@services/trakt/trakt.types';
 
 import { TraktApi } from './trakt.api';
 
@@ -38,7 +39,7 @@ export class TraktService {
   /**
    * Check device authentication status and complete login
    */
-  async checkDeviceAuth(deviceCode: string, userId: string) {
+  async checkDeviceAuth(deviceCode: string, userId: string): Promise<DeviceAuthCheckResponse> {
     try {
       // Get the user first
       const user = await this.userRepository.findById(userId);

--- a/backend/src/services/trakt/trakt.types.ts
+++ b/backend/src/services/trakt/trakt.types.ts
@@ -294,3 +294,16 @@ export type TraktListItem =
   | TraktListItemMovie
   | TraktListItemSeason
   | TraktListItemShow;
+
+export interface DeviceAuthCheckSuccess {
+  success: true;
+  traktUsername: string;
+  traktSlug: string;
+}
+
+export interface DeviceAuthCheckPending {
+  success: false;
+  pending: true;
+}
+
+export type DeviceAuthCheckResponse = DeviceAuthCheckPending | DeviceAuthCheckSuccess;


### PR DESCRIPTION
## Summary
- define request and response interfaces for API routes
- expose DTOs via backend client
- update route handlers to use the new types
- refine service return types to avoid casts
- move shared service DTOs to separate files

## Testing
- `npm run check:ts`
- `npm test`
- `npm -w backend run build:client`
- `npm -w packages/backend-client run build`


------
https://chatgpt.com/codex/tasks/task_e_686de952f4dc8330b0a5912abbd1d60f