### PR TITLE
Add mock database implementation for testing

### DIFF
--- a/backend/src/__mocks__/@database/database.ts
+++ b/backend/src/__mocks__/@database/database.ts
@@ -1,0 +1,296 @@
+import type { EntityTarget, ObjectLiteral, Repository } from 'typeorm';
+
+import type { Episode } from '@entities/episode.entity';
+import type { Genre } from '@entities/genre.entity';
+import type { Movie } from '@entities/movie.entity';
+import type { MovieSource } from '@entities/movie-source.entity';
+import type { RefreshToken } from '@entities/refresh-token.entity';
+import type { Storage } from '@entities/storage.entity';
+import type { StreamingKey } from '@entities/streaming-key.entity';
+import type { User } from '@entities/user.entity';
+import { UserRole } from '@entities/user.entity';
+import type { AuditLogRepository } from '@repositories/audit-log.repository';
+import type { GenreRepository } from '@repositories/genre.repository';
+import type { MediaListRepository } from '@repositories/mediaList.repository';
+import type { MovieRepository } from '@repositories/movie.repository';
+import type { MovieSourceRepository } from '@repositories/movie-source.repository';
+import type { ProgressRepository } from '@repositories/progress.repository';
+import type { RefreshTokenRepository } from '@repositories/refresh-token.repository';
+import type { StorageRepository } from '@repositories/storage.repository';
+import type { StreamingKeyRepository } from '@repositories/streaming-key.repository';
+import type { SyncStateRepository } from '@repositories/syncState.repository';
+import type { TraktUserRepository } from '@repositories/trakt-user.repository';
+import type { TVShowRepository } from '@repositories/tvshow.repository';
+import type { UserRepository } from '@repositories/user.repository';
+import type { EncryptionService } from '@services/encryption/encryption.service';
+
+// Mock MovieRepository
+const createMockMovieRepository = (): jest.Mocked<MovieRepository> => {
+  return {
+    findByTMDBId: jest.fn(
+      (_tmdbId: number | string): Promise<Movie | null> => Promise.resolve(null)
+    ),
+    create: jest.fn(details =>
+      Promise.resolve({
+        id: 1,
+        tmdbId: details.tmdbId,
+        title: details.title,
+        overview: details.overview,
+        tagline: details.tagline,
+        releaseDate: details.releaseDate,
+        poster: details.poster,
+        backdrop: details.backdrop,
+        logo: details.logo,
+        runtime: details.runtime,
+        popularity: details.popularity,
+        rating: details.rating,
+        genres: details.genres || [],
+        translations: [],
+      } as unknown as Movie)
+    ),
+    addTranslation: jest.fn(() => Promise.resolve({})),
+    checkForChangesAndUpdate: jest.fn(() => Promise.resolve({})),
+    updateGenres: jest.fn(() => Promise.resolve({})),
+    findByIds: jest.fn(() => Promise.resolve([])),
+    findById: jest.fn(() => Promise.resolve(null)),
+    findMoviesPendingSourceSearch: jest.fn(() => Promise.resolve([])),
+    findMoviesWithoutSources: jest.fn(() => Promise.resolve([])),
+  } as unknown as jest.Mocked<MovieRepository>;
+};
+
+// Mock GenreRepository
+const createMockGenreRepository = (): jest.Mocked<GenreRepository> => {
+  return {
+    findAll: jest.fn(() =>
+      Promise.resolve([
+        { id: 1, name: 'Action', translations: [{ language: 'en' }] },
+      ] as unknown as Genre[])
+    ),
+    createOrGetGenre: jest.fn(id =>
+      Promise.resolve({
+        id,
+        name: 'Mocked Genre',
+        translations: [{ language: 'en' }],
+      } as unknown as Genre)
+    ),
+    createTranslation: jest.fn(() => Promise.resolve()),
+  } as unknown as jest.Mocked<GenreRepository>;
+};
+
+// Mock SyncStateRepository
+const createMockSyncStateRepository = (): jest.Mocked<SyncStateRepository> => {
+  return {
+    getLastSync: jest.fn((): Promise<Date | null> => Promise.resolve(null)),
+    setLastSync: jest.fn((): Promise<void> => Promise.resolve()),
+    getByName: jest.fn(() => Promise.resolve(null)),
+  } as unknown as jest.Mocked<SyncStateRepository>;
+};
+
+// Mock MovieSourceRepository
+const createMockMovieSourceRepository = (): jest.Mocked<MovieSourceRepository> => {
+  return {
+    create: jest.fn((source: Partial<MovieSource>) =>
+      Promise.resolve({ id: 1, ...source } as MovieSource)
+    ),
+    createMany: jest.fn(() => Promise.resolve([])),
+    findByMovieId: jest.fn(() => Promise.resolve([])),
+    findByMovieAndHash: jest.fn(() => Promise.resolve(null)),
+    getRepository: jest.fn(() => ({}) as Repository<MovieSource>),
+    findSourcesToProcess: jest.fn(() => Promise.resolve([])),
+    updateStats: jest.fn(() => Promise.resolve()),
+    findBestSourceForMovie: jest.fn(() => Promise.resolve(null)),
+  } as unknown as jest.Mocked<MovieSourceRepository>;
+};
+
+const createMockUser = (overrides: Partial<User> = {}): User => {
+  const now = new Date();
+  return {
+    id: 'user-123',
+    email: 'mock@example.com',
+    passwordHash: '',
+    role: UserRole.USER,
+    isEmailVerified: false,
+    displayName: null,
+    refreshTokens: [],
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+};
+
+const createMockRefreshToken = (overrides: Partial<RefreshToken> = {}): RefreshToken => {
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + 86400000);
+  const baseUser = createMockUser();
+  return {
+    id: 'token-123',
+    tokenHash: 'mock-token-hash',
+    expiresAt,
+    userId: 'user-123',
+    session: 'mock-session',
+    userAgent: null,
+    lastIpAddress: null,
+    lastAccessedAt: now,
+    accessCount: 1,
+    issueIpAddress: null,
+    user: baseUser,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+};
+
+// Mock UserRepository
+const createMockUserRepository = (): jest.Mocked<UserRepository> => {
+  return {
+    findByEmail: jest.fn(() => Promise.resolve(null)),
+    findByRole: jest.fn(() => Promise.resolve([])),
+    create: jest.fn(user => Promise.resolve(createMockUser(user as Partial<User>))),
+    findById: jest.fn(() => Promise.resolve(null)),
+    update: jest.fn(() => Promise.resolve(null)),
+    delete: jest.fn(() => Promise.resolve(false)),
+    saveUser: jest.fn(user => Promise.resolve(createMockUser(user as Partial<User>))),
+  } as unknown as jest.Mocked<UserRepository>;
+};
+
+// Mock RefreshTokenRepository
+const createMockRefreshTokenRepository = (): jest.Mocked<RefreshTokenRepository> => {
+  return {
+    findByToken: jest.fn(() => Promise.resolve(null)),
+    create: jest.fn((tokenData: Partial<RefreshToken> & { token?: string }) => {
+      const { token: _omit, ...rest } = tokenData;
+      void _omit; // Raw token is hashed in real impl; omitted in mock
+      return Promise.resolve(createMockRefreshToken({ ...rest, id: 'token-123' }));
+    }),
+    updateToken: jest.fn(() => Promise.resolve(false)),
+    isChainExpired: jest.fn(() => Promise.resolve(false)),
+    delete: jest.fn(() => Promise.resolve(false)),
+    countByUser: jest.fn(() => Promise.resolve(0)),
+    deleteOldestByUser: jest.fn(() => Promise.resolve(false)),
+    deleteByUserAndSession: jest.fn(() => Promise.resolve(false)),
+    findById: jest.fn(() => Promise.resolve(null)),
+    findByUser: jest.fn(() => Promise.resolve([])),
+    deleteByUser: jest.fn(() => Promise.resolve(false)),
+    deleteExpired: jest.fn(() => Promise.resolve(0)),
+    saveRefreshToken: jest.fn(token => Promise.resolve(createMockRefreshToken(token))),
+    findByUserAndSession: jest.fn(() => Promise.resolve(null)),
+  } as unknown as jest.Mocked<RefreshTokenRepository>;
+};
+
+// Mock StreamingKeyRepository (used by AuthService)
+const createMockStreamingKeyRepository = (): jest.Mocked<StreamingKeyRepository> => {
+  return {
+    create: jest.fn(() => Promise.resolve({} as unknown as StreamingKey)),
+    findByKeyHash: jest.fn(() => Promise.resolve(null)),
+    deleteByKeyHash: jest.fn(() => Promise.resolve()),
+    deleteExpired: jest.fn(() => Promise.resolve(0)),
+    deleteByUserId: jest.fn(() => Promise.resolve(0)),
+    deleteByMovieId: jest.fn(() => Promise.resolve(0)),
+  } as unknown as jest.Mocked<StreamingKeyRepository>;
+};
+
+// Mock StorageRepository
+const createMockStorageRepository = (): jest.Mocked<StorageRepository> => {
+  return {
+    findById: jest.fn(() => Promise.resolve(null)),
+    findByMovieSourceId: jest.fn(() => Promise.resolve(null)),
+    findByMovieSourceIdWithRelation: jest.fn(() => Promise.resolve(null)),
+    create: jest.fn((storage: Partial<Storage>) =>
+      Promise.resolve({ id: 1, ...storage } as Storage)
+    ),
+    update: jest.fn(() => Promise.resolve(null)),
+    delete: jest.fn(() => Promise.resolve(false)),
+    deleteByMovieSourceId: jest.fn(() => Promise.resolve(false)),
+    updateLastAccess: jest.fn(() => Promise.resolve()),
+    updateDownloadProgress: jest.fn(() => Promise.resolve()),
+    findOldUnaccessed: jest.fn(() => Promise.resolve([])),
+    findMostStaleStorage: jest.fn(() => Promise.resolve(null)),
+    getStorageCount: jest.fn(() => Promise.resolve(0)),
+    getTotalStorageUsage: jest.fn(() => Promise.resolve(BigInt(0))),
+    findByDownloadedRange: jest.fn(() => Promise.resolve([])),
+  } as unknown as jest.Mocked<StorageRepository>;
+};
+
+// Mock Database class
+export class Database {
+  private movieRepository: jest.Mocked<MovieRepository>;
+  private genreRepository: jest.Mocked<GenreRepository>;
+  private syncStateRepository: jest.Mocked<SyncStateRepository>;
+  private tvShowRepository: jest.Mocked<TVShowRepository>;
+  private progressRepository: jest.Mocked<ProgressRepository>;
+  private seasonRepository: jest.Mocked<Record<string, unknown>>;
+  private mediaListRepository: jest.Mocked<MediaListRepository>;
+  private movieSourceRepository: jest.Mocked<MovieSourceRepository>;
+  private userRepository: jest.Mocked<UserRepository>;
+  private refreshTokenRepository: jest.Mocked<RefreshTokenRepository>;
+  private auditLogRepository: jest.Mocked<AuditLogRepository>;
+  private traktUserRepository: jest.Mocked<TraktUserRepository>;
+  private storageRepository: jest.Mocked<StorageRepository>;
+  private streamingKeyRepository: jest.Mocked<StreamingKeyRepository>;
+
+  // Make getter methods jest mocks so they can be overridden
+  public getMovieRepository: jest.Mock;
+  public getTVShowRepository: jest.Mock;
+  public getGenreRepository: jest.Mock;
+  public getSyncStateRepository: jest.Mock;
+  public getProgressRepository: jest.Mock;
+  public getSeasonRepository: jest.Mock;
+  public getMediaListRepository: jest.Mock;
+  public getMovieSourceRepository: jest.Mock;
+  public getUserRepository: jest.Mock;
+  public getRefreshTokenRepository: jest.Mock;
+  public getAuditLogRepository: jest.Mock;
+  public getTraktUserRepository: jest.Mock;
+  public getStorageRepository: jest.Mock;
+  public getStreamingKeyRepository: jest.Mock;
+
+  constructor(_encryptionService?: EncryptionService) {
+    // Initialize all repositories with default mocks
+    this.movieRepository = createMockMovieRepository();
+    this.genreRepository = createMockGenreRepository();
+    this.syncStateRepository = createMockSyncStateRepository();
+    this.tvShowRepository = {} as jest.Mocked<TVShowRepository>;
+    this.progressRepository = {} as jest.Mocked<ProgressRepository>;
+    this.seasonRepository = {} as jest.Mocked<Record<string, unknown>>;
+    this.mediaListRepository = {} as jest.Mocked<MediaListRepository>;
+    this.movieSourceRepository = createMockMovieSourceRepository();
+    this.userRepository = createMockUserRepository();
+    this.refreshTokenRepository = createMockRefreshTokenRepository();
+    this.auditLogRepository = {} as jest.Mocked<AuditLogRepository>;
+    this.traktUserRepository = {} as jest.Mocked<TraktUserRepository>;
+    this.storageRepository = createMockStorageRepository();
+    this.streamingKeyRepository = createMockStreamingKeyRepository();
+
+    // Initialize getter methods as jest mocks that return the repositories
+    this.getMovieRepository = jest.fn(() => this.movieRepository);
+    this.getTVShowRepository = jest.fn(() => this.tvShowRepository);
+    this.getGenreRepository = jest.fn(() => this.genreRepository);
+    this.getSyncStateRepository = jest.fn(() => this.syncStateRepository);
+    this.getProgressRepository = jest.fn(() => this.progressRepository);
+    this.getSeasonRepository = jest.fn(() => this.seasonRepository);
+    this.getMediaListRepository = jest.fn(() => this.mediaListRepository);
+    this.getMovieSourceRepository = jest.fn(() => this.movieSourceRepository);
+    this.getUserRepository = jest.fn(() => this.userRepository);
+    this.getRefreshTokenRepository = jest.fn(() => this.refreshTokenRepository);
+    this.getAuditLogRepository = jest.fn(() => this.auditLogRepository);
+    this.getTraktUserRepository = jest.fn(() => this.traktUserRepository);
+    this.getStorageRepository = jest.fn(() => this.storageRepository);
+    this.getStreamingKeyRepository = jest.fn(() => this.streamingKeyRepository);
+  }
+
+  async initialize(): Promise<void> {
+    // Mock implementation - no-op
+  }
+
+  async close(): Promise<void> {
+    // Mock implementation - no-op
+  }
+
+  getRepository<T extends ObjectLiteral>(_entity: EntityTarget<T>): Repository<T> {
+    return {} as Repository<T>;
+  }
+
+  getEpisodeRepository(): Repository<Episode> {
+    return {} as Repository<Episode>;
+  }
+}

--- a/backend/src/content-directories/therarbg/index.test.ts
+++ b/backend/src/content-directories/therarbg/index.test.ts
@@ -1,7 +1,7 @@
 import { MockCache } from '@__test-utils__/cache.mock';
 import { Quality, Source, VideoCodec } from '@miauflix/source-metadata-extractor';
 
-import type { Database } from '@database/database';
+import { Database } from '@database/database';
 import { DownloadService } from '@services/download/download.service';
 import { RequestService } from '@services/request/request.service';
 import { StatsService } from '@services/stats/stats.service';
@@ -13,6 +13,7 @@ import type { ImdbDetailPost, ImdbMetadata } from './therarbg.types';
 jest.mock('@services/download/download.service');
 jest.mock('@services/storage/storage.service');
 jest.mock('@services/request/request.service');
+jest.mock('@database/database');
 
 describe('TherarbgContentDirectory', () => {
   afterEach(() => {
@@ -21,7 +22,9 @@ describe('TherarbgContentDirectory', () => {
 
   const setupTest = () => {
     const mockCache = new MockCache();
-    const mockStorageService = new StorageService({} as Database) as jest.Mocked<StorageService>;
+    const mockStorageService = new StorageService(
+      new Database({} as never)
+    ) as jest.Mocked<StorageService>;
 
     const statsService = new StatsService();
     const mockRequestService = new RequestService(
@@ -430,7 +433,7 @@ describe('TherarbgContentDirectory', () => {
       const statsService = new StatsService();
       const realRequestService = new RequestServiceImpl(statsService);
       const realDownloadService = new DownloadService(
-        new StorageService({} as Database) as jest.Mocked<StorageService>,
+        new StorageService(new Database({} as never)) as jest.Mocked<StorageService>,
         realRequestService
       ) as jest.Mocked<DownloadService>;
       realDownloadService.generateLink.mockImplementation((hash: string, trackers: string[]) => {

--- a/backend/src/services/auth/auth.service.test.ts
+++ b/backend/src/services/auth/auth.service.test.ts
@@ -1,13 +1,12 @@
 import type { Context } from 'hono';
 
-import type { Database } from '@database/database';
+import { Database } from '@database/database';
 import { AuditEventSeverity, AuditEventType } from '@entities/audit-log.entity';
 import type { RefreshToken } from '@entities/refresh-token.entity';
 import type { User } from '@entities/user.entity';
 import { UserRole } from '@entities/user.entity';
 import { InvalidTokenError } from '@errors/auth.errors';
 import type { RefreshTokenRepository } from '@repositories/refresh-token.repository';
-import type { StreamingKeyRepository } from '@repositories/streaming-key.repository';
 import type { UserRepository } from '@repositories/user.repository';
 import type { AuditLogService } from '@services/security/audit-log.service';
 
@@ -15,6 +14,7 @@ import { AuthService } from './auth.service';
 
 // Mock the ENV function - must be hoisted
 jest.mock('@constants');
+jest.mock('@database/database');
 
 // Mock the tracing decorator
 jest.mock('@utils/tracing.util', () => ({
@@ -57,7 +57,6 @@ describe('AuthService', () => {
   let mockDatabase: jest.Mocked<Database>;
   let mockUserRepository: jest.Mocked<UserRepository>;
   let mockRefreshTokenRepository: jest.Mocked<RefreshTokenRepository>;
-  let mockStreamingKeyRepository: jest.Mocked<StreamingKeyRepository>;
   let mockAuditLogService: jest.Mocked<AuditLogService>;
   let mockContext: Context;
 
@@ -65,31 +64,10 @@ describe('AuthService', () => {
   const { ENV } = jest.requireMock('@constants');
 
   const setupTest = () => {
-    // Create mock repositories
-    mockUserRepository = {
-      findByEmail: jest.fn(),
-      findByRole: jest.fn(),
-      create: jest.fn(),
-    } as unknown as jest.Mocked<UserRepository>;
-
-    mockRefreshTokenRepository = {
-      findByToken: jest.fn(),
-      create: jest.fn(),
-      updateToken: jest.fn(),
-      isChainExpired: jest.fn(),
-      delete: jest.fn(),
-      countByUser: jest.fn(),
-      deleteOldestByUser: jest.fn(),
-      deleteByUserAndSession: jest.fn(),
-    } as unknown as jest.Mocked<RefreshTokenRepository>;
-
-    mockStreamingKeyRepository = {} as unknown as jest.Mocked<StreamingKeyRepository>;
-
-    mockDatabase = {
-      getUserRepository: jest.fn(() => mockUserRepository),
-      getRefreshTokenRepository: jest.fn(() => mockRefreshTokenRepository),
-      getStreamingKeyRepository: jest.fn(() => mockStreamingKeyRepository),
-    } as unknown as jest.Mocked<Database>;
+    mockDatabase = new Database({} as never) as jest.Mocked<Database>;
+    mockUserRepository = mockDatabase.getUserRepository() as jest.Mocked<UserRepository>;
+    mockRefreshTokenRepository =
+      mockDatabase.getRefreshTokenRepository() as jest.Mocked<RefreshTokenRepository>;
 
     mockAuditLogService = {
       logSecurityEvent: jest.fn(),

--- a/backend/src/services/download/download.service.test.ts
+++ b/backend/src/services/download/download.service.test.ts
@@ -8,7 +8,7 @@ import { Client as BTClient } from 'bittorrent-tracker';
 import loadIPSet from 'load-ip-set';
 
 import { ENV } from '@constants';
-import type { Database } from '@database/database';
+import { Database } from '@database/database';
 import type { RequestServiceResponse } from '@services/request/request.service';
 import { RequestService } from '@services/request/request.service';
 import { StatsService } from '@services/stats/stats.service';
@@ -24,6 +24,7 @@ jest.mock('load-ip-set');
 jest.mock('@logger');
 jest.mock('@services/storage/storage.service');
 jest.mock('@services/request/request.service');
+jest.mock('@database/database');
 
 describe('DownloadService', () => {
   beforeEach(() => {
@@ -74,7 +75,9 @@ describe('DownloadService', () => {
     }
 
     // Mock StorageService as EventEmitter
-    const mockStorageService = new StorageService({} as Database) as jest.Mocked<StorageService>;
+    const mockStorageService = new StorageService(
+      new Database({} as never)
+    ) as jest.Mocked<StorageService>;
 
     const service = new DownloadService(mockStorageService, mockRequestService);
 

--- a/backend/src/services/media/media.service.test.ts
+++ b/backend/src/services/media/media.service.test.ts
@@ -1,70 +1,41 @@
+jest.mock('@database/database');
+
 import { MockCache } from '@__test-utils__/cache.mock';
 import { logger as mockLogger } from '@logger';
 
-import type { Database } from '@database/database';
+import { Database } from '@database/database';
 import type { Movie } from '@entities/movie.entity';
 import { StatsService } from '@services/stats/stats.service';
 import { TMDBApi } from '@services/tmdb/tmdb.api';
 
 import { MediaService } from './media.service';
 
-const mockMovieRepo = {
-  findByTMDBId: jest.fn((_tmdbId: number | string): Promise<Movie | null> => Promise.resolve(null)),
-  create: jest.fn(details =>
-    Promise.resolve({
-      id: 1,
-      tmdbId: details.tmdbId,
-      title: details.title,
-      overview: details.overview,
-      tagline: details.tagline,
-      releaseDate: details.releaseDate,
-      poster: details.poster,
-      backdrop: details.backdrop,
-      logo: details.logo,
-      runtime: details.runtime,
-      popularity: details.popularity,
-      rating: details.rating,
-      genres: details.genres || [],
-      translations: [],
-    } as unknown as Movie)
-  ),
-  addTranslation: jest.fn(() => Promise.resolve({})),
-  checkForChangesAndUpdate: jest.fn(() => Promise.resolve({})),
-  updateGenres: jest.fn(() => Promise.resolve({})),
-};
-
-const mockGenreRepo = {
-  findAll: jest.fn(() =>
-    Promise.resolve([{ id: 1, name: 'Action', translations: [{ language: 'en' }] }])
-  ),
-  createOrGetGenre: jest.fn(id =>
-    Promise.resolve({ id, name: 'Mocked Genre', translations: [{ language: 'en' }] })
-  ),
-  createTranslation: jest.fn(() => Promise.resolve({})),
-};
-
-const mockSyncStateRepo = {
-  getLastSync: jest.fn((): Promise<Date | null> => Promise.resolve(null)),
-  setLastSync: jest.fn((): Promise<void> => Promise.resolve()),
-};
-
 const theWildRobotTMDBID = 1184918; // Movie: The Wild Robot
 const cosmicPrincessTMDBID = 346698; // Movie: Cosmic Princess
-
-const mockDb = {
-  getMovieRepository: () => mockMovieRepo,
-  getTVShowRepository: () => ({}),
-  getGenreRepository: () => mockGenreRepo,
-  getProgressRepository: () => ({}),
-  getSyncStateRepository: () => mockSyncStateRepo,
-  getSeasonRepository: () => ({}),
-} as unknown as Database;
 
 const mockFetch = global.fetch as unknown as jest.Mock<typeof global.fetch>;
 
 describe('MediaService', () => {
+  let mockDb: Database;
+  let mockMovieRepo: jest.Mocked<ReturnType<Database['getMovieRepository']>>;
+  let mockGenreRepo: jest.Mocked<ReturnType<Database['getGenreRepository']>>;
+  let mockSyncStateRepo: jest.Mocked<ReturnType<Database['getSyncStateRepository']>>;
+
   const setupTest = async () => {
     process.env.TMDB_API_ACCESS_TOKEN = 'test-token';
+
+    // Create a new Database instance (which will be the mock)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockDb = new Database({} as any);
+    mockMovieRepo = mockDb.getMovieRepository() as jest.Mocked<
+      ReturnType<Database['getMovieRepository']>
+    >;
+    mockGenreRepo = mockDb.getGenreRepository() as jest.Mocked<
+      ReturnType<Database['getGenreRepository']>
+    >;
+    mockSyncStateRepo = mockDb.getSyncStateRepository() as jest.Mocked<
+      ReturnType<Database['getSyncStateRepository']>
+    >;
 
     // Create the MediaService with the mock DB and a new TMDBApi instance
     const mockCache = new MockCache();

--- a/backend/src/services/source-metadata/content-directory.service.test.ts
+++ b/backend/src/services/source-metadata/content-directory.service.test.ts
@@ -6,8 +6,9 @@ import { StorageService } from '@services/storage/storage.service';
 
 jest.mock('@services/download/download.service');
 jest.mock('@services/storage/storage.service');
+jest.mock('@database/database');
 
-import type { Database } from '@database/database';
+import { Database } from '@database/database';
 import { DownloadService } from '@services/download/download.service';
 
 import { ContentDirectoryService } from './content-directory.service';
@@ -19,7 +20,9 @@ describe('ContentDirectoryService', () => {
     const mockCache = new MockCache();
 
     // Create a mock StorageService
-    const mockStorageService = new StorageService({} as Database) as jest.Mocked<StorageService>;
+    const mockStorageService = new StorageService(
+      new Database({} as never)
+    ) as jest.Mocked<StorageService>;
 
     const statsService = new StatsService();
     // Use real RequestService - HTTP-VCR will intercept fetch calls ( already recorded calls will not go out to the real API )

--- a/backend/src/services/storage/__tests__/storage.service.test.ts
+++ b/backend/src/services/storage/__tests__/storage.service.test.ts
@@ -1,3 +1,5 @@
+jest.unmock('@database/database');
+
 import { createTestDatabase, type TestDatabaseHelper } from '@__test-utils__/database.helpers';
 import { TestDataFactory } from '@__test-utils__/test-data.factory';
 import fs from 'fs';


### PR DESCRIPTION
- Introduced a new mock database file in `backend/src/__mocks__/@database/database.ts` to facilitate testing by providing mocked repositories for various entities.
- Updated multiple test files to utilize the new mock database, ensuring consistent and reliable test setups across services.
- Refactored existing tests to replace direct database instantiation with the mock database, improving test isolation and maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced mock database infrastructure to provide consistent, reusable test setup across multiple test suites.
  * Updated test files to utilize standardized mock database instances, improving test reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->